### PR TITLE
Round 2: re-fix M70 segfault and iscircle handling

### DIFF
--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -1902,7 +1902,7 @@ static void output_to_hal(void)
     /* Line and Motion Type (Casting to int for s32 HAL pins) */
     *(emcmot_hal_data->interp_line_number)      = (int)emcmotStatus->tag.fields[GM_FIELD_LINE_NUMBER];
     *(emcmot_hal_data->interp_motion_type)      = (int)emcmotStatus->tag.fields[GM_FIELD_MOTION_MODE];
-	*(emcmot_hal_data->iscircle)      = (int)emcmotStatus->tag.fields[GM_FLAG_IS_CIRCLE];
+    *(emcmot_hal_data->iscircle)                = (hal_bit_t)((emcmotStatus->tag.packed_flags & (1UL << GM_FLAG_IS_CIRCLE)) != 0);
     switch (emcmotStatus->motionType) {
         case EMC_MOTION_TYPE_FEED: //fall thru
         case EMC_MOTION_TYPE_ARC:
@@ -2265,19 +2265,15 @@ static void update_status(void)
 			/* --- G2/G3: DYNAMIC ARC HEADING --- */
 			double cx = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_CENTER_X];
 			double cy = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_ARC_CENTER_Y];
-			*(emcmot_hal_data->interp_normal_heading) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_NORMAL_HEADING];
-			*(emcmot_hal_data->iscircle) = (hal_bit_t)((emcmotStatus->tag.packed_flags & (1 << GM_FLAG_IS_CIRCLE)) != 0);
+			*(emcmot_hal_data->iscircle) = (hal_bit_t)((emcmotStatus->tag.packed_flags & (1UL << GM_FLAG_IS_CIRCLE)) != 0);
 			// Current RT feedback position
 			double dx = emcmotStatus->carte_pos_fb.tran.x - cx;
 			double dy = emcmotStatus->carte_pos_fb.tran.y - cy;
 			double angle_rad = atan2(dy, dx);
 			// Normal heading is tool-to-centre (opposite of radial)
 			double normal_heading_deg = (angle_rad * (180.0 / M_PI)) + 180.0;
-    
-			// 0-360 Normalization
 			while (normal_heading_deg < 0) normal_heading_deg += 360.0;
 			while (normal_heading_deg >= 360.0) normal_heading_deg -= 360.0;
-    
 			*(emcmot_hal_data->interp_normal_heading) = normal_heading_deg;
 			
 			double heading_deg;
@@ -2301,13 +2297,13 @@ static void update_status(void)
 			if (emcmot_hal_data->interp_feedrate) {
 				*(emcmot_hal_data->interp_feedrate) = emcmotStatus->tag.fields_float[GM_FIELD_FLOAT_FEED];
 			}
-		}		
+		}
 	}
-}
 #ifdef WATCH_FLAGS
-/*! \todo FIXME - this is for debugging */
-if ( old_motion_flag != emcmotStatus->motionFlag ) {
-rtapi_print ( "Motion flag %04X -> %04X\n", old_motion_flag, emcmotStatus->motionFlag );
-old_motion_flag = emcmotStatus->motionFlag;
-}
+    /*! \todo FIXME - this is for debugging */
+    if ( old_motion_flag != emcmotStatus->motionFlag ) {
+	rtapi_print ( "Motion flag %04X -> %04X\n", old_motion_flag, emcmotStatus->motionFlag );
+	old_motion_flag = emcmotStatus->motionFlag;
+    }
 #endif
+}

--- a/src/emc/rs274ngc/interp_write.cc
+++ b/src/emc/rs274ngc/interp_write.cc
@@ -334,13 +334,14 @@ int Interp::write_state_tag(block_pointer block,
     state.fields_float[GM_FIELD_FLOAT_FEED] = settings->feed_rate;
     state.fields_float[GM_FIELD_FLOAT_SPEED] = settings->speed[0];
     
-    // Pack new geometric data
-    state.fields_float[GM_FIELD_FLOAT_STRAIGHT_HEADING] = (block == NULL)  ? 0.0f : (float)block->arc_heading;
-	state.fields_float[GM_FIELD_FLOAT_ARC_RADIUS]       = (block == NULL)  ? 0.0f : (float)block->arc_radius;
-	state.fields_float[GM_FIELD_FLOAT_ARC_CENTER_X]     = (block == NULL)  ? 0.0f : (float)block->arc_center_x;
-	state.fields_float[GM_FIELD_FLOAT_ARC_CENTER_Y]     = (block == NULL)  ? 0.0f : (float)block->arc_center_y;
-	state.fields_float[GM_FIELD_FLOAT_NORMAL_HEADING]   = (block == NULL)  ? 0.0f : (float)block->normal_heading;
-	state.flags[GM_FLAG_IS_CIRCLE] = block->iscircle	= (block == NULL)  ? 0    : (bool)block->iscircle;
+    // Pack new geometric data. block is NULL on the M70 save path
+    // (save_settings() in interp_convert.cc), so guard against null deref.
+    state.fields_float[GM_FIELD_FLOAT_STRAIGHT_HEADING] = (block == NULL) ? 0.0f : (float)block->arc_heading;
+    state.fields_float[GM_FIELD_FLOAT_ARC_RADIUS]       = (block == NULL) ? 0.0f : (float)block->arc_radius;
+    state.fields_float[GM_FIELD_FLOAT_ARC_CENTER_X]     = (block == NULL) ? 0.0f : (float)block->arc_center_x;
+    state.fields_float[GM_FIELD_FLOAT_ARC_CENTER_Y]     = (block == NULL) ? 0.0f : (float)block->arc_center_y;
+    state.fields_float[GM_FIELD_FLOAT_NORMAL_HEADING]   = (block == NULL) ? 0.0f : (float)block->normal_heading;
+    state.flags[GM_FLAG_IS_CIRCLE]                      = (block == NULL) ? false : block->iscircle;
 
     return 0;
 }

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -2228,22 +2228,19 @@ int Interp::active_modes(int *g_codes,
         tag.flags[GM_FLAG_FEED_HOLD] ? 53 : -1;
 
 
-    // Copy float-type state
-    for (i=0; i<GM_FIELD_FLOAT_MAX_FIELDS; i++)
-		settings[i] = tag.fields_float[i];
-
     // Copy float-type state. settings[] is sized ACTIVE_SETTINGS (5);
     // GM_FIELD_FLOAT_MAX_FIELDS may be larger when extra tag fields are
     // appended for HAL pin output. Cap at the smaller of the two to avoid
     // overrunning the caller's stack array.
-    int n = GM_FIELD_FLOAT_MAX_FIELDS < ACTIVE_SETTINGS ? GM_FIELD_FLOAT_MAX_FIELDS : ACTIVE_SETTINGS;
-	for (i=0; i<n; i++)
-		settings[i] = tag.fields_float[i];
-    //settings[0] = tag.fields[GM_FIELD_LINE_NUMBER];
+    int n = GM_FIELD_FLOAT_MAX_FIELDS < ACTIVE_SETTINGS
+	? GM_FIELD_FLOAT_MAX_FIELDS : ACTIVE_SETTINGS;
+    for (i=0; i<n; i++)
+	settings[i] = tag.fields_float[i];
     // Line number stored in double; this demonstrates why the current
     // system of unpacking state tags into arrays of fixed type and
     // purpose should be refactored into something more elegant
-	// Where do we update tag.fields[GM_FLAG_IS_CIRCLE]
+    settings[0] = tag.fields[GM_FIELD_LINE_NUMBER];
+
     return INTERP_OK;
 }
 


### PR DESCRIPTION
Follow-up to #9. The fixes from that PR were partly reapplied in 8a869ec ('M70 problems') and 1321309 ('add normalheading and an iscircle flag'), but three regressions remain. After this PR, all 3 m70-m73 tests pass locally.

## 1. `active_modes()` in rs274ngc_pre.cc still smashes the stack

Current state on this branch:

```c
for (i=0; i<GM_FIELD_FLOAT_MAX_FIELDS; i++)        // <-- still here, still overruns
    settings[i] = tag.fields_float[i];

int n = GM_FIELD_FLOAT_MAX_FIELDS < ACTIVE_SETTINGS ? ... ;
for (i=0; i<n; i++)                                 // clamped copy
    settings[i] = tag.fields_float[i];
//settings[0] = tag.fields[GM_FIELD_LINE_NUMBER];   // commented out
```

The original unclamped loop was kept above the clamped one, so the 40-byte stack overflow into the caller's `double saved_settings[ACTIVE_SETTINGS]` is unchanged. The line-number copy was also commented out, which would silently drop the line number from the unpacked state on M72/M73/abort restores.

Fix: drop the duplicate, keep only the clamped loop, restore the line-number copy.

## 2. `write_state_tag()` still NULL-derefs on M70

```c
state.flags[GM_FLAG_IS_CIRCLE] = block->iscircle = (block == NULL) ? 0 : (bool)block->iscircle;
```

`block->iscircle = ...` dereferences `block` before the ternary is evaluated; on the M70 save path `save_settings()` passes `block == NULL`, so this segfaults again. The other five lines were correctly null-guarded.

Fix: drop the self-assignment and use a plain null-guarded read like the others.

## 3. `output_to_hal()` reads iscircle from the wrong array

```c
*(emcmot_hal_data->iscircle) = (int)emcmotStatus->tag.fields[GM_FLAG_IS_CIRCLE];
```

`GM_FLAG_IS_CIRCLE` is a `StateFlag` (enum index into `packed_flags`), but `tag.fields[]` is sized `GM_FIELD_MAX_FIELDS == 8`. `GM_FLAG_IS_CIRCLE` evaluates to 24, indexing 16 entries past the end of `fields[]`. The companion read in `update_status()` does the right thing via `packed_flags & (1UL << GM_FLAG_IS_CIRCLE)`; output_to_hal() now matches it.

While in the file: dropped a duplicate `interp_normal_heading` write in the G2/G3 branch (it was assigned twice with different values), and restored the closing brace of `update_status()` so the `WATCH_FLAGS` debug block stays inside the function.

## Test plan

* [x] Local build clean (gcc).
* [x] `scripts/runtests tests/m70-m73`: 3/3 pass (was 0/3 on this branch tip).