### PR TITLE
Fix RTAI build: M_PI_2 undeclared

### DIFF
--- a/src/emc/motion/control.c
+++ b/src/emc/motion/control.c
@@ -2280,11 +2280,11 @@ static void update_status(void)
 
 			// G3 (CCW): Heading is Radial Angle + 90 degrees
 			if (motion_type == 30) {
-				heading_deg = (angle_rad + M_PI_2) * (180.0 / M_PI);
-			} 
+				heading_deg = (angle_rad + (M_PI / 2.0)) * (180.0 / M_PI);
+			}
 			// G2 (CW): Heading is Radial Angle - 90 degrees
 			else {
-				heading_deg = (angle_rad - M_PI_2) * (180.0 / M_PI);
+				heading_deg = (angle_rad - (M_PI / 2.0)) * (180.0 / M_PI);
 			}
 			// 0-360 Normalization
 			while (heading_deg < 0) heading_deg += 360.0;


### PR DESCRIPTION
LinuxCNC PR #3995's RTAI job fails:

```
src/emc/motion/control.c:2283:60: error: 'M_PI_2' undeclared (first use in this function); did you mean 'M_PI_2l'?
```

`M_PI_2` is a glibc/`_GNU_SOURCE` extension that is not exposed by RTAI's `rtapi_math.h`. `M_PI` is available in both, so replace `M_PI_2` with `M_PI / 2.0` in the two G2/G3 heading lines.

## Test plan

* [x] Local uspace build clean.
* [ ] CI RTAI job (verifies on push).